### PR TITLE
calculator: Overflow and layout fixes

### DIFF
--- a/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorButton.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorButton.java
@@ -34,12 +34,14 @@ import lombok.extern.slf4j.Slf4j;
 public class CalculatorButton extends JButton
 {
 	private static final Dimension PREFERRED_SIZE = new Dimension(55, 55);
+	private static final Dimension MINIMUM_SIZE = new Dimension(54, 55);
 
 	public CalculatorButton(String text)
 	{
 		super(text);
 
 		setPreferredSize(PREFERRED_SIZE);
+		setMinimumSize(MINIMUM_SIZE);
 		// Use Arial. Zero and Asterisk look funny in "Runescape Standard"
 		setFont(new Font("Arial", Font.BOLD, 20));
 	}
@@ -49,5 +51,6 @@ public class CalculatorButton extends JButton
 		super(icon);
 
 		setPreferredSize(PREFERRED_SIZE);
+		setMinimumSize(MINIMUM_SIZE);
 	}
 }

--- a/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.swing.ImageIcon;
 import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
 import net.runelite.client.util.ImageUtil;
 import org.apache.commons.lang3.StringUtils;
 
@@ -62,11 +63,14 @@ public class CalculatorPanel extends JPanel
 		this.displayField = panel.getDisplayField();
 
 		setLayout(new GridBagLayout());
+		setBorder(new EmptyBorder(0, 1, 0, 1));
 
 		c = new GridBagConstraints();
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.gridx = 0;
 		c.gridy = 0;
+		c.weightx = 1;
+		c.weighty = 1;
 
 		CalculatorButton plusMinus = new CalculatorButton(PLUS_MINUS_ICON);
 

--- a/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
@@ -145,7 +145,7 @@ public class CalculatorPanel extends JPanel
 				displayField.calculateResult();
 				if (displayField.getResult() == null)
 				{
-					// Divide by 0 error occured
+					// Divide by 0 or overflow error occured
 					return;
 				}
 				// Add new calculation to history before the displayField is updated

--- a/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
@@ -172,49 +172,19 @@ public class CalculatorPanel extends JPanel
 					// If there is no action saved, assume we're working with num1
 					if (displayField.getCalculatorAction() == null)
 					{
-						Integer num1 = displayField.getNum1();
-						if (num1 == 0)
-						{
-							if (displayField.num1IsNegativeZero())
-							{
-								num *= -1;
-							}
-							displayField.setNum1(num);
-						}
-						else
-						{
-							if (num1 < 0)
-							{
-								displayField.setNum1(num1 * 10 - num);
-							}
-							else
-							{
-								displayField.setNum1(num1 * 10 + num);
-							}
-						}
+						displayField.setNum1(
+							getNewNumber(
+								displayField.getNum1(),
+								num,
+								displayField.num1IsNegativeZero()));
 					}
 					else
 					{
-						Integer num2 = displayField.getNum2();
-						if (num2 == null || num2 == 0)
-						{
-							if (displayField.num2IsNegativeZero())
-							{
-								num *= -1;
-							}
-							displayField.setNum2(num);
-						}
-						else
-						{
-							if (num2 < 0)
-							{
-								displayField.setNum2(num2 * 10 - num);
-							}
-							else
-							{
-								displayField.setNum2(num2 * 10 + num);
-							}
-						}
+						displayField.setNum2(
+							getNewNumber(
+								displayField.getNum2(),
+								num,
+								displayField.num2IsNegativeZero()));
 					}
 				}
 			}
@@ -252,6 +222,54 @@ public class CalculatorPanel extends JPanel
 			displayField.update();
 		});
 		addComp(btn);
+	}
+
+	private int getNewNumber(Integer oldNum, int newNum, boolean isNegativeZero)
+	{
+		if (oldNum == null || oldNum == 0)
+		{
+			if (isNegativeZero)
+			{
+				return newNum * -1;
+			}
+			return newNum;
+		}
+		else
+		{
+			if (oldNum < 0)
+			{
+				if (oldNum < Integer.MIN_VALUE / 10)
+				{
+					return Integer.MIN_VALUE;
+				}
+				try
+				{
+					return Math.subtractExact(oldNum * 10, newNum);
+				}
+				catch (ArithmeticException e)
+				{
+					return Integer.MIN_VALUE;
+				}
+			}
+			else
+			{
+				if (oldNum > Integer.MAX_VALUE / 10)
+				{
+					return Integer.MAX_VALUE;
+				}
+				else
+				{
+					try
+					{
+						return Math.addExact(oldNum * 10, newNum);
+					}
+					catch (ArithmeticException e)
+					{
+						return Integer.MAX_VALUE;
+					}
+				}
+			}
+		}
 	}
 
 	private void addComp(Component component)

--- a/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
@@ -238,40 +238,27 @@ public class CalculatorPanel extends JPanel
 			}
 			return newNum;
 		}
+
+		if (oldNum < 0)
+		{
+			try
+			{
+				return Math.subtractExact(Math.multiplyExact(oldNum, 10), newNum);
+			}
+			catch (ArithmeticException e)
+			{
+				return Integer.MIN_VALUE;
+			}
+		}
 		else
 		{
-			if (oldNum < 0)
+			try
 			{
-				if (oldNum < Integer.MIN_VALUE / 10)
-				{
-					return Integer.MIN_VALUE;
-				}
-				try
-				{
-					return Math.subtractExact(oldNum * 10, newNum);
-				}
-				catch (ArithmeticException e)
-				{
-					return Integer.MIN_VALUE;
-				}
+				return Math.addExact(Math.multiplyExact(oldNum, 10), newNum);
 			}
-			else
+			catch (ArithmeticException e)
 			{
-				if (oldNum > Integer.MAX_VALUE / 10)
-				{
-					return Integer.MAX_VALUE;
-				}
-				else
-				{
-					try
-					{
-						return Math.addExact(oldNum * 10, newNum);
-					}
-					catch (ArithmeticException e)
-					{
-						return Integer.MAX_VALUE;
-					}
-				}
+				return Integer.MAX_VALUE;
 			}
 		}
 	}

--- a/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/CalculatorPanel.java
@@ -46,7 +46,7 @@ public class CalculatorPanel extends JPanel
 
 	static
 	{
-		final BufferedImage plusMinusIcon = ImageUtil.resizeImage(ImageUtil.getResourceStreamFromClass(CalculatorPlugin.class, "plus_minus_icon.png"), 25, 25);
+		final BufferedImage plusMinusIcon = ImageUtil.resizeImage(ImageUtil.loadImageResource(CalculatorPlugin.class, "plus_minus_icon.png"), 25, 25);
 		PLUS_MINUS_ICON = new ImageIcon(plusMinusIcon);
 	}
 

--- a/src/main/java/com/thenorsepantheon/calculator/ui/DisplayField.java
+++ b/src/main/java/com/thenorsepantheon/calculator/ui/DisplayField.java
@@ -60,13 +60,40 @@ public class DisplayField extends JTextField
 		switch (calculatorAction)
 		{
 			case ADDITION:
-				result = num1 + num2;
+				try
+				{
+					result = Math.addExact(num1, num2);
+				}
+				catch (ArithmeticException e)
+				{
+					reset();
+					super.setText("Error: Addition overflow!");
+					finished = true;
+				}
 				break;
 			case SUBTRACTION:
-				result = num1 - num2;
+				try
+				{
+					result = Math.subtractExact(num1, num2);
+				}
+				catch (ArithmeticException e)
+				{
+					reset();
+					super.setText("Error: Subtraction overflow!");
+					finished = true;
+				}
 				break;
 			case MULTIPLICATION:
-				result = num1 * num2;
+				try
+				{
+					result = Math.multiplyExact(num1, num2);
+				}
+				catch (ArithmeticException e)
+				{
+					reset();
+					super.setText("Error: Multiplication overflow!");
+					finished = true;
+				}
 				break;
 			case DIVISION:
 				if (num2 == 0)


### PR DESCRIPTION
I made some tweaks to your calculator plugin:

Fixes the calculator overflowing and displaying weird numbers when adding too many numbers.

Fixes the layout breaking whenever too many items appear in the history and the scrollbar appears.

Prevents add/sub/mult operations that cause an overflow.